### PR TITLE
Fix overriding options using jit tasks

### DIFF
--- a/grunt/load-grunt.js
+++ b/grunt/load-grunt.js
@@ -22,13 +22,15 @@ module.exports = function(grunt, settings) {
             customTasksDir: settings.tasks,
             staticMappings: settings.mappings || {},
         },
+        init: false,
 
         postProcess: settings.postProcess || _.noop(),
         preMerge: preMerge,
     };
 
     // Start our load-grunt-config
-    require('load-grunt-config')(grunt, config);
+    var gruntConfig = require('load-grunt-config')(grunt, config);
+    grunt.initConfig(gruntConfig);
 
     function preMerge(mConfig, options) {
         var tasks = Object.keys(mConfig);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-grunt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The only grunt boilerplate you need!",
   "main": "GruntFile.js",
   "scripts": {
@@ -9,8 +9,8 @@
     "grunt": "cd test;grunt config"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/wardpeet/global-grunt.git"
+    "type": "git",
+    "url": "https://github.com/wardpeet/global-grunt.git"
   },
   "bugs": "https://github.com/wardpeet/global-grunt/issues",
   "keywords": [

--- a/test/data/defaultSettings.js
+++ b/test/data/defaultSettings.js
@@ -6,6 +6,8 @@ module.exports = function(rootDir) {
         tasks: path.join(rootDir, 'grunt/tasks'),
         override: path.join(rootDir, 'grunt/tasks/config'),
 
+        jitGrunt: true,
+
         default: {
             env: 'test',
             src: 'src/',

--- a/test/grunt/tasks/jit.js
+++ b/test/grunt/tasks/jit.js
@@ -1,0 +1,8 @@
+module.exports = function(grunt) {
+    grunt.config('env', 'prod');
+
+    // Default task
+    grunt.registerTask('jit', function() {
+        grunt.log.writeln(JSON.stringify(grunt.config()));
+    });
+};

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,20 @@ exports.testPassesOptionsToOverride = function(test) {
     defaultFailTest(promise, test);
 };
 
+exports.testPassesOptionsInsideTasks = function(test) {
+    test.expect(1);
+
+    var promise = spawnGrunt('GruntFile.js', ['--env=preview'], 'jit').then(function(response) {
+        var data = parseJson(response);
+
+        test.strictEqual('prod', data.env);
+
+        test.done();
+    });
+
+    defaultFailTest(promise, test);
+};
+
 function spawnGrunt(gruntFile, args, command) {
     args = args || [];
     command = command || 'config';


### PR DESCRIPTION
We would like to update options & settings of grunt before a task is running. For example forcing environment local when serving local.
